### PR TITLE
Implement POST endpoint for creating a new post

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,7 +95,35 @@ app.post('/api/v1/users', async (request, response) => {
 
   try {
     const id = await database('users').insert(user, 'id');
-    response.status(201).json(user)
+    response.status(201).json({ id })
+  } catch(error) {
+    response.status(500).json({ error });
+  }
+});
+
+app.post('/api/v1/users/:id/posts', async (request, response) => {
+  let post = request.body;
+
+  for (let requiredParameter of ['retweet_count', 'favorite_count', 'full_text', 'user_id']) {
+    if (!post[requiredParameter]) {
+      return response
+        .status(422)
+        .send({ error: `Expected format: { retweet_count: <Integer>, favorite_count: <Integer>, full_text: <String>, user_id: <Integer> }. You're missing a "${requiredParameter}" property.` });
+    }
+  }
+  var today = new Date();
+  var dd = String(today.getDate()).padStart(2, '0');
+  var mm = String(today.getMonth() + 1).padStart(2, '0'); //January is 0!
+  var yyyy = today.getFullYear();
+
+  today = yyyy + '-' + mm + '-' + dd;
+  post = {
+    post_created_at: today,
+    ...post
+  }
+  try {
+    const id = await database('posts').insert(post, 'id');
+    response.status(201).json({ id })
   } catch(error) {
     response.status(500).json({ error });
   }


### PR DESCRIPTION
#### What's this PR do?
 - This PR adds a POST endpoint for a user to create a new post. The POST takes in the retweet count and favorite count (this would typically be generated behind the scenes, but for this purpose it is just put in initially, which doesn't completely replicate the real use of this) It also then takes in the text of the post and the user id that the post is associated with. Within the endpoint using new Date() the endpoint gives it today's date before pushing to database.

#### Where should the reviewer start?
 - Look at the server.js file to see the POST endoint to posts